### PR TITLE
fix: do not crash if no devices are found

### DIFF
--- a/Ratatouille/standalone/xpa.h
+++ b/Ratatouille/standalone/xpa.h
@@ -84,6 +84,7 @@ public:
         [](Devices const &a, Devices const &b) {
             return a.order < b.order; 
         });
+        if (devices.empty()) return false;
         auto it = devices.begin();
         PaStreamParameters inputParameters;
         inputParameters.device = it->index;


### PR DESCRIPTION
On nixos without this modification simply crash at startup.